### PR TITLE
Error handling improvements for embed commands

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -24,23 +24,6 @@ client.on('interactionCreate', async interaction => {
 	const command = client.commands.get(interaction.commandName);
 	if (!command) return;
 
-	if (interaction.channel.type !== 'dm') {
-		try {
-			const permissions = interaction.guild.me.permissionsIn(interaction.channel);
-
-			// message.author.send(`My permissions in the \`${message.channel.name}\` channel on \`${message.guild.name}\` are as follows\n\`\`\`${permissions.serialize()}\`\`\``);
-
-			if (!permissions.has('SEND_MESSAGES')) {
-				interaction.author.send(`I am unable to send a message in the \`${interaction.channel.name}\` channel on \`${interaction.guild.name}\`\nPlease make sure I have permission to send messages in that channel`);
-				return;
-			}
-		}
-		catch (error) {
-			console.error(error);
-			interaction.author.send(`There was an error trying to determine permissions: \`${error.name}\` \`\`\`\n${error.message}\`\`\``);
-		}
-	}
-
 	try {
 		await command.execute(interaction);
 	}

--- a/command-utils.js
+++ b/command-utils.js
@@ -46,4 +46,11 @@ module.exports = {
 
 		return option;
 	},
+
+	// Check for given permission in current channel of the provided interaction
+	hasPermission(interaction, permission) {
+		const permissions = interaction.guild.me.permissionsIn(interaction.channel);
+
+		return permissions.has(permission);
+	},
 };

--- a/commands/create-embed.js
+++ b/commands/create-embed.js
@@ -43,12 +43,35 @@ module.exports = {
 			serverData.port = options.getNumber('port');
 		}
 
+		// Check for permissions required to send an embed message
+		if (!CommandUtils.hasPermission(interaction, 'VIEW_CHANNEL')) {
+			interaction.reply({ content: 'I do not seem to be able to access this channel\nPlease ensure I have permission to view this channel', ephemeral: true });
+			return;
+		}
+		else if (!CommandUtils.hasPermission(interaction, 'SEND_MESSAGES')) {
+			interaction.reply({ content: 'I am unable to send a message in this channel\nPlease ensure I have permission to send messages in this channel', ephemeral: true });
+			return;
+		}
+		else if (!CommandUtils.hasPermission(interaction, 'EMBED_LINKS')) {
+			interaction.reply({ content: 'I am unable to send an embed message in this channel\nPlease ensure I have permission to embed links in this channel', ephemeral: true });
+			return;
+		}
+		else if (!CommandUtils.hasPermission(interaction, 'ATTACH_FILES')) {
+			interaction.reply({ content: 'I am unable to send an image in this channel\nPlease ensure I have permission to attach files in this channel', ephemeral: true });
+			return;
+		}
+
 		// Create self-updating server status embed
 		interaction.reply({ content: `Creating new self-updating status embed with the ID \`${embedId}\`...`, ephemeral: true });
 		ServerUtils.createStatusEmbed(interaction.client, embedId, serverData, function sendEmbed(statusEmbed, fileArray) {
 			return interaction.channel.send({ embeds: [statusEmbed], files: fileArray });
 		}).then(() => {
-			interaction.editReply({ content: `Successfully created new self-updating status embed with the ID \`${embedId}\``, ephemeral: true });
+			if (CommandUtils.hasPermission(interaction, 'READ_MESSAGE_HISTORY')) {
+				interaction.editReply({ content: `Successfully created new self-updating status embed with the ID \`${embedId}\``, ephemeral: true });
+			}
+			else {
+				interaction.editReply({ content: `I was able to successfully create the new self-updating status embed with the ID \`${embedId}\`, but I seem to be unable to access it\n**Please ensure I have permission to read message history in this channel, or I will not be able to keep the server status embeds in this channel up to date**` });
+			}
 		}).catch(error => {
 			interaction.editReply({ content: `Failed to create new status embed \`${embedId}\`:\n\`\`\`${error}\`\`\``, ephemeral: true });
 			console.log(`Failed to create new status embed \`${embedId}\`:`);

--- a/commands/create-embed.js
+++ b/commands/create-embed.js
@@ -23,21 +23,21 @@ module.exports = {
 			.setDescription('Enter the port used to reach the server')),
 	execute(interaction) {
 		const options = interaction.options;
-		let embedId = null;
-		const serverData = {
-			type: null,
-
-			address: null,
-			port: null,
-		};
 
 		// Handle args
-		embedId = options.getString('embed-id');
+		const embedId = options.getString('embed-id');
 		if (ServerUtils.isEmbedIdTaken(embedId, interaction.guild.id, interaction.channel.id)) {
 			interaction.reply({ content: `An embed with the ID \`${embedId}\` already exists in this channel.\nPlease try again with a different ID`, ephemeral: true });
 			return;
 		}
-		serverData.type = options.getString('server-type');
+
+		const serverType = options.getString('server-type');
+
+		const serverData = {
+			type: serverType,
+			...ServerUtils.getDefaultServerData(serverType),
+		};
+
 		serverData.address = options.getString('address');
 		if (options.getNumber('port') !== undefined) {
 			serverData.port = options.getNumber('port');

--- a/commands/create-embed.js
+++ b/commands/create-embed.js
@@ -74,8 +74,8 @@ module.exports = {
 			}
 		}).catch(error => {
 			interaction.editReply({ content: `Failed to create new status embed \`${embedId}\`:\n\`\`\`${error}\`\`\``, ephemeral: true });
-			console.log(`Failed to create new status embed \`${embedId}\`:`);
-			console.log(error);
+			console.log(`Failed to create new status embed '${embedId}':`);
+			console.error(error);
 		});
 	},
 };

--- a/commands/delete-embed.js
+++ b/commands/delete-embed.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
 const ServerUtils = require('../server-utils.js');
+const CommandUtils = require('../command-utils');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -14,6 +15,16 @@ module.exports = {
 
 		// Handle args
 		const embedId = options.getString('embed-id');
+
+		// Check for permissions required to delete an embed message
+		if (!CommandUtils.hasPermission(interaction, 'VIEW_CHANNEL')) {
+			interaction.reply({ content: 'I do not seem to be able to access this channel\nPlease ensure I have permission to view this channel', ephemeral: true });
+			return;
+		}
+		else if (!CommandUtils.hasPermission(interaction, 'READ_MESSAGE_HISTORY')) {
+			interaction.reply({ content: 'I am unable to see the status embed in this channel\nPlease ensure I have permission to read message history in this channel', ephemeral: true });
+			return;
+		}
 
 		// Delete self-updating server status embed
 		ServerUtils.deleteStatusEmbed(interaction.client, embedId, interaction.guild.id, interaction.channel.id).then(messageContent => {

--- a/commands/delete-embed.js
+++ b/commands/delete-embed.js
@@ -30,7 +30,9 @@ module.exports = {
 		ServerUtils.deleteStatusEmbed(interaction.client, embedId, interaction.guild.id, interaction.channel.id).then(messageContent => {
 			interaction.reply({ content: messageContent, ephemeral: true });
 		}).catch(error => {
-			console.log(`The delete-embed command encountered an error: ${error}`);
+			interaction.reply({ content: `Failed to delete status embed \`${embedId}\`:\n\`\`\`${error}\`\`\``, ephemeral: true });
+			console.log(`Failed to delete status embed '${embedId}':`);
+			console.error(error);
 		});
 	},
 };

--- a/commands/edit-embed-attribute.js
+++ b/commands/edit-embed-attribute.js
@@ -42,9 +42,14 @@ module.exports = {
 
 		// Edit self-updating server status embed
 		embedData.serverData[attributeId] = newValue;
-		ServerUtils.setStatusEmbedData(interaction.client, embedId, interaction.guild.id, interaction.channel.id, embedData).then(embedFile => {
-			interaction.reply({ content: `Succesfully set the attribute \`${attributeId}\` to \`${newValue}\` for the status embed with the id \`${embedId}\` in this channel`, ephemeral: true });
-			console.log(`Successfully set new data in status embed \`${embedFile}\``);
+		ServerUtils.setStatusEmbedData(embedId, interaction.guild.id, interaction.channel.id, embedData).then(embedFile => {
+			ServerUtils.updateStatusEmbed(interaction.client, embedFile).then(() => {
+				console.log(`Successfully set new data in status embed \`${embedFile}\``);
+				interaction.reply({ content: `Succesfully set the attribute \`${attributeId}\` to \`${newValue}\` for the status embed with the id \`${embedId}\` in this channel`, ephemeral: true });
+			}).catch(error => {
+				interaction.reply({ content: `I managed to set the attribute \`${attributeId}\` to \`${newValue}\` in the data for the status embed with the id \`${embedId}\`, but I was not able to edit the status embed to show the new data:\n\`\`\`${error}\`\`\``, ephemeral: true });
+				console.error(`Failed to update status embed \`${embedFile}\`:\n${error}`);
+			});
 		}).catch((error, embedFile) => {
 			interaction.reply({ content: `Failed to change data of status embed \`${embedId}\`:\n\`\`\`${error}\`\`\``, ephemeral: true });
 			console.error(`Failed to set new data in status embed \`${embedFile}\`:\n${error}`);

--- a/commands/edit-embed-attribute.js
+++ b/commands/edit-embed-attribute.js
@@ -26,7 +26,7 @@ module.exports = {
 		const newValue = options.getString('value');
 
 		const embedData = ServerUtils.getStatusEmbedData(embedId, interaction.guild.id, interaction.channel.id);
-		const serverDataAttributes = ServerUtils.getServerDataAttributes(embedData.serverData.type);
+		const serverDataAttributes = ServerUtils.getServerDataTemplate(embedData.serverData.type);
 
 		// Check if attribute id is valid
 		if (!(attributeId in serverDataAttributes)) {

--- a/commands/edit-embed-attribute.js
+++ b/commands/edit-embed-attribute.js
@@ -25,8 +25,14 @@ module.exports = {
 		const attributeId = options.getString('attribute');
 		const newValue = options.getString('value');
 
+		if (!ServerUtils.isEmbedIdTaken(embedId, interaction.guild.id, interaction.channel.id)) {
+			interaction.reply({ content: `An embed with the ID \`${embedId}\` does not exist in this channel.\nPlease try again with a different ID`, ephemeral: true });
+			return;
+		}
+
 		const embedData = ServerUtils.getStatusEmbedData(embedId, interaction.guild.id, interaction.channel.id);
 		const serverDataAttributes = ServerUtils.getServerDataTemplate(embedData.serverData.type);
+
 
 		// Check if attribute id is valid
 		if (!(attributeId in serverDataAttributes)) {

--- a/commands/edit-embed-attribute.js
+++ b/commands/edit-embed-attribute.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
 const ServerUtils = require('../server-utils');
+const CommandUtils = require('../command-utils');
 
 module.exports = {
 	data: new SlashCommandBuilder()
@@ -43,13 +44,22 @@ module.exports = {
 		// Edit self-updating server status embed
 		embedData.serverData[attributeId] = newValue;
 		ServerUtils.setStatusEmbedData(embedId, interaction.guild.id, interaction.channel.id, embedData).then(embedFile => {
+			const errorMessage = `I managed to set the attribute \`${attributeId}\` to \`${newValue}\` in the data for the status embed with the id \`${embedId}\`, but I was not able to edit the status embed to show the new data`;
+
+			// Check for permissions required to update an embed message
+			if (!CommandUtils.hasPermission(interaction, 'VIEW_CHANNEL') || !CommandUtils.hasPermission(interaction, 'READ_MESSAGE_HISTORY')) {
+				interaction.reply({ content: `${errorMessage}. **This appears to be due to missing permissions, so please ensure that I have permission to view this channel and read it's message history**. Once these permissions are sorted out the new data will become visible on the next automatic update or edit`, ephemeral: true });
+				return;
+			}
+
 			ServerUtils.updateStatusEmbed(interaction.client, embedFile).then(() => {
 				console.log(`Successfully set new data in status embed \`${embedFile}\``);
 				interaction.reply({ content: `Succesfully set the attribute \`${attributeId}\` to \`${newValue}\` for the status embed with the id \`${embedId}\` in this channel`, ephemeral: true });
 			}).catch(error => {
-				interaction.reply({ content: `I managed to set the attribute \`${attributeId}\` to \`${newValue}\` in the data for the status embed with the id \`${embedId}\`, but I was not able to edit the status embed to show the new data:\n\`\`\`${error}\`\`\``, ephemeral: true });
+				interaction.reply({ content: `${errorMessage}:\n\`\`\`${error}\`\`\``, ephemeral: true });
 				console.error(`Failed to update status embed \`${embedFile}\`:\n${error}`);
 			});
+
 		}).catch((error, embedFile) => {
 			interaction.reply({ content: `Failed to change data of status embed \`${embedId}\`:\n\`\`\`${error}\`\`\``, ephemeral: true });
 			console.error(`Failed to set new data in status embed \`${embedFile}\`:\n${error}`);

--- a/commands/list-server-attributes.js
+++ b/commands/list-server-attributes.js
@@ -17,7 +17,7 @@ module.exports = {
 		const serverType = options.getString('server-type');
 
 		// Get attributes
-		const attributes = ServerUtils.getServerDataAttributes(serverType);
+		const attributes = ServerUtils.getServerDataTemplate(serverType);
 
 		// Create list
 		let message = `Attributes for \`${interaction.client.pingTypes.get(serverType).name}\` servers:`;

--- a/server-utils.js
+++ b/server-utils.js
@@ -12,7 +12,7 @@ function getEmbedFile(embedId, guildId, channelId) {
 }
 
 // Returns path to attribute data for provided server ping type
-function getServerDataAttributePath(serverType) {
+function getServerDataTemplatePath(serverType) {
 	return `${serverTypeDirectory}/${serverType}-data.json`;
 }
 
@@ -202,8 +202,8 @@ class ServerUtils {
 	}
 
 	// Get server attributes for given server ping type
-	static getServerDataAttributes(serverType) {
-		const serverDataPath = getServerDataAttributePath(serverType);
+	static getServerDataTemplate(serverType) {
+		const serverDataPath = getServerDataTemplatePath(serverType);
 
 		return JSON.parse(fs.readFileSync(serverDataPath));
 	}

--- a/server-utils.js
+++ b/server-utils.js
@@ -208,6 +208,18 @@ class ServerUtils {
 		return JSON.parse(fs.readFileSync(serverDataPath));
 	}
 
+	static getDefaultServerData(serverType) {
+		const serverDataPath = getServerDataTemplatePath(serverType);
+		const serverDataTemplate = JSON.parse(fs.readFileSync(serverDataPath));
+		const serverData = {};
+
+		for (const attribute in serverDataTemplate) {
+			serverData[attribute] = serverDataTemplate[attribute].defaultValue;
+		}
+
+		return serverData;
+	}
+
 	// Set embed data in self-updating server status embed
 	static setStatusEmbedData(client, embedId, guildId, channelId, newEmbedData) {
 		return new Promise((resolve, reject) => {


### PR DESCRIPTION
- Improved error handling for missing permissions when running commands
- Added user-facing error message for unknown failures in the delete-embed command
- Improved the error message for when the given embed ID does not exist when running the edit-embed-attribute command
- Creating a new status embed now uses the default data found in the data.json file for the corresponding server type