### PR TITLE
Bugfix: default port must be specified

### DIFF
--- a/commands/edit-embed-attribute.js
+++ b/commands/edit-embed-attribute.js
@@ -23,23 +23,21 @@ module.exports = {
 
 		// Handle args
 		const embedId = options.getString('embed-id');
-		const attributeId = options.getString('attribute');
-		const newValue = options.getString('value');
-
 		if (!ServerUtils.isEmbedIdTaken(embedId, interaction.guild.id, interaction.channel.id)) {
 			interaction.reply({ content: `An embed with the ID \`${embedId}\` does not exist in this channel.\nPlease try again with a different ID`, ephemeral: true });
 			return;
 		}
-
 		const embedData = ServerUtils.getStatusEmbedData(embedId, interaction.guild.id, interaction.channel.id);
 		const serverDataAttributes = ServerUtils.getServerDataTemplate(embedData.serverData.type);
 
-
-		// Check if attribute id is valid
+		const attributeId = options.getString('attribute');
 		if (!(attributeId in serverDataAttributes)) {
 			interaction.reply({ content: `Failed to change the attribute for the server status embed with the id \`${embedId}\` in this channel as the server ping type of \`${embedData.serverData.type}\` does not support using the attribute \`${attributeId}\``, ephemeral: true });
 			return;
 		}
+
+		const newValue = options.getString('value');
+
 
 		// Edit self-updating server status embed
 		embedData.serverData[attributeId] = newValue;

--- a/commands/edit-embed-attribute.js
+++ b/commands/edit-embed-attribute.js
@@ -36,7 +36,10 @@ module.exports = {
 			return;
 		}
 
-		const newValue = options.getString('value');
+		const newValue = ((attributeId == 'port') ?
+			parseInt(options.getString('value')) :
+			options.getString('value')
+		);
 
 
 		// Edit self-updating server status embed

--- a/ping_type/minecraft.js
+++ b/ping_type/minecraft.js
@@ -9,7 +9,10 @@ module.exports = {
 
 	ping(serverData) {
 		return new Promise((resolve) => {
-			minecraftServerUtil.status(serverData.address, serverData.port).then(pingData => {
+			minecraftServerUtil.status(
+				serverData.address,
+				((serverData.port == null) ? 25565 : serverData.port),
+			).then(pingData => {
 				pingData.online = true;
 				pingData.motd = pingData.motd.clean;
 


### PR DESCRIPTION
- Fixed default port not being used when value is null
- Fixed edit-embed-attribute command saving ports as a string instead of a number